### PR TITLE
Flush LZW decoder output in case of error

### DIFF
--- a/lzw_reader.go
+++ b/lzw_reader.go
@@ -154,6 +154,7 @@ func (d *lzwDecoder) decode() {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
 			}
+			d.flush()
 			d.err = err
 			return
 		}
@@ -205,6 +206,7 @@ func (d *lzwDecoder) decode() {
 				d.prefix[d.hi] = d.last
 			}
 		default:
+			d.flush()
 			d.err = errors.New("lzw: invalid code")
 			return
 		}


### PR DESCRIPTION
I have encountered elevation-data GeoTIFFs where some of the blocks are missing the terminating end-of-information code in the LZW stream. That is, all the data is there, but an exception (either "unexpected eof" or "invalid code") is thrown at the end.
These files are accepted e.g. by QGIS.
This commit adds flushes of the output data in these circumstances, which enables the calling code to check if there is enough decoded data and silently proceed in this case. 